### PR TITLE
Allow use with Cabal >= 1.22

### DIFF
--- a/cabal-dependency-licenses.cabal
+++ b/cabal-dependency-licenses.cabal
@@ -24,7 +24,7 @@ Executable cabal-dependency-licenses
   Ghc-options:         -Wall
 
   Build-depends:
-    Cabal      >= 1.20 && < 1.21,
+    Cabal      >= 1.20 && < 1.23,
     containers >= 0.5  && < 0.6,
     base       >= 4    && < 5,
     directory  >= 1.2  && < 1.3,

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 --------------------------------------------------------------------------------
 module Main
     ( main
@@ -35,10 +36,15 @@ existsCabalFile = do
     contents <- getDirectoryContents "."
     return $ any ((== ".cabal") . takeExtension) contents
 
-
 --------------------------------------------------------------------------------
+#if MIN_VERSION_Cabal(1,22,0)
+type PackageIndex a = Cabal.PackageIndex (InstalledPackageInfo.InstalledPackageInfo_ a)
+#else
+type PackageIndex a = Cabal.PackageIndex
+#endif
+
 findTransitiveDependencies
-    :: Cabal.PackageIndex
+    :: PackageIndex a
     -> Set Cabal.InstalledPackageId
     -> Set Cabal.InstalledPackageId
 findTransitiveDependencies pkgIdx set0 = go Set.empty (Set.toList set0)


### PR DESCRIPTION
Firstly, thanks for making and publishing this, it saved me a lot of pain :)

I made some changes which appear to allow it to work with Cabal 1.22.x. I've tested this with Cabal-1.20.0.0 and 1.22.0.0, on `purescript`, and it exits successfully and outputs the full list of dependencies with licence types as I'd expect in both cases.