### PR TITLE
Bump filepath upper version bounds

### DIFF
--- a/cabal-dependency-licenses.cabal
+++ b/cabal-dependency-licenses.cabal
@@ -28,7 +28,7 @@ Executable cabal-dependency-licenses
     containers >= 0.5  && < 0.6,
     base       >= 4    && < 5,
     directory  >= 1.2  && < 1.3,
-    filepath   >= 1.3  && < 1.4
+    filepath   >= 1.3  && < 1.5
 
 Source-repository head
     Type:     git


### PR DESCRIPTION
Allow `cabal-dependency-licenses` to build with `filepath-1.4`.