### PR TITLE
Include dependency copyright notices in output when available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 dist
+dist-newstyle
+.ghc.environment.*
+*~
+cabal.project.local*

--- a/cabal-dependency-licenses.cabal
+++ b/cabal-dependency-licenses.cabal
@@ -23,8 +23,8 @@ Category:           Distribution
 Build-type:         Simple
 Extra-source-files: CHANGELOG
 Cabal-version:      >= 1.10
-Homepage:           http://github.com/jaspervdj/cabal-dependency-licenses
-Bug-reports:        http://github.com/jaspervdj/cabal-dependency-licenses/issues
+Homepage:           http://github.com/matterhorn-chat/cabal-dependency-licenses
+Bug-reports:        http://github.com/matterhorn-chat/cabal-dependency-licenses/issues
 
 Executable cabal-dependency-licenses
   Hs-source-dirs:      src

--- a/cabal-dependency-licenses.cabal
+++ b/cabal-dependency-licenses.cabal
@@ -24,11 +24,12 @@ Executable cabal-dependency-licenses
   Ghc-options:         -Wall
 
   Build-depends:
-    Cabal      >= 1.18 && < 1.25,
+    Cabal      >= 1.24 && < 1.25,
     containers >= 0.5  && < 0.6,
     base       >= 4    && < 5,
     directory  >= 1.2  && < 1.4,
-    filepath   >= 1.3  && < 1.5
+    filepath   >= 1.3  && < 1.5,
+    filemanip
 
 Source-repository head
     Type:     git

--- a/cabal-dependency-licenses.cabal
+++ b/cabal-dependency-licenses.cabal
@@ -33,7 +33,7 @@ Executable cabal-dependency-licenses
   Ghc-options:         -Wall
 
   Build-depends:
-                Cabal      >= 2
+                Cabal      >= 1.24.0.0
               , containers >= 0.5  && < 0.7
               , base       >= 4    && < 5
               , directory  >= 1.2  && < 1.4

--- a/cabal-dependency-licenses.cabal
+++ b/cabal-dependency-licenses.cabal
@@ -24,12 +24,12 @@ Executable cabal-dependency-licenses
   Ghc-options:         -Wall
 
   Build-depends:
-    Cabal      >= 2,
-    containers >= 0.5  && < 0.6,
-    base       >= 4    && < 5,
-    directory  >= 1.2  && < 1.4,
-    filepath   >= 1.3  && < 1.5,
-    filemanip
+                Cabal      >= 2
+              , containers >= 0.5  && < 0.6
+              , base       >= 4    && < 5
+              , directory  >= 1.2  && < 1.4
+              , filepath   >= 1.3  && < 1.5
+              , filemanip
 
 Source-repository head
     Type:     git

--- a/cabal-dependency-licenses.cabal
+++ b/cabal-dependency-licenses.cabal
@@ -25,7 +25,7 @@ Executable cabal-dependency-licenses
 
   Build-depends:
                 Cabal      >= 2
-              , containers >= 0.5  && < 0.6
+              , containers >= 0.5  && < 0.7
               , base       >= 4    && < 5
               , directory  >= 1.2  && < 1.4
               , filepath   >= 1.3  && < 1.5

--- a/cabal-dependency-licenses.cabal
+++ b/cabal-dependency-licenses.cabal
@@ -1,14 +1,23 @@
 Name:     cabal-dependency-licenses
-Version:  0.2.0.1
+Version:  0.2.0.1.1
 Synopsis: Compose a list of a project's transitive dependencies with their licenses
 
 Description:
-  Compose a list of a project's transitive dependencies with their licenses
+            Compose a list of a project's transitive dependencies with their licenses
+            .
+            Note: this version differs from the original
+            implementation by Jasper Van der Jeugt in that it takes a
+            different approach to handling dist-newstyle, and it has
+            other enhancements such as SPDX handling.  The original
+            version is relatively unmaintained; this version contains
+            all substantive modifications to the original through 12
+            Mar 2019 (through commit 47e927b in the original
+            repository).
 
 License:            BSD3
 License-file:       LICENSE
 Author:             Jasper Van der Jeugt <m@jaspervdj.be>
-Maintainer:         Jasper Van der Jeugt <m@jaspervdj.be>
+Maintainer:         Jonathan Daugherty, Kevin Quick
 Copyright:          2014 Jasper Van der Jeugt
 Category:           Distribution
 Build-type:         Simple
@@ -33,4 +42,4 @@ Executable cabal-dependency-licenses
 
 Source-repository head
     Type:     git
-    Location: https://github.com/jaspervdj/cabal-dependency-licenses
+    Location: https://github.com/matterhorn-chat/cabal-dependency-licenses

--- a/cabal-dependency-licenses.cabal
+++ b/cabal-dependency-licenses.cabal
@@ -1,5 +1,5 @@
 Name:     cabal-dependency-licenses
-Version:  0.2.0.0
+Version:  0.2.0.1
 Synopsis: Compose a list of a project's transitive dependencies with their licenses
 
 Description:
@@ -24,7 +24,7 @@ Executable cabal-dependency-licenses
   Ghc-options:         -Wall
 
   Build-depends:
-    Cabal      >= 1.24 && < 1.25,
+    Cabal      >= 2,
     containers >= 0.5  && < 0.6,
     base       >= 4    && < 5,
     directory  >= 1.2  && < 1.4,

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -14,7 +14,9 @@ import           Data.Set                           (Set)
 import qualified Data.Set                           as Set
 import qualified Data.Map                           as Map
 import           Distribution.InstalledPackageInfo  (InstalledPackageInfo)
+import qualified Distribution.SPDX.License          as SPDX
 import qualified Distribution.InstalledPackageInfo  as InstalledPackageInfo
+import qualified Distribution.Pretty                as Pretty
 import qualified Distribution.License               as Cabal
 import qualified Distribution.Package               as Cabal
 import qualified Distribution.Simple.Configure      as Cabal
@@ -92,7 +94,7 @@ getDependencyInstalledPackageInfos lbi = catMaybes $
 --------------------------------------------------------------------------------
 groupByLicense
     :: [InstalledPackageInfo]
-    -> [(Cabal.License, [InstalledPackageInfo])]
+    -> [(Either SPDX.License Cabal.License, [InstalledPackageInfo])]
 groupByLicense = foldl'
     (\assoc ipi -> insert (InstalledPackageInfo.license ipi) ipi assoc) []
   where
@@ -108,11 +110,14 @@ groupByLicense = foldl'
 
 --------------------------------------------------------------------------------
 printDependencyLicenseList
-    :: [(Cabal.License, [InstalledPackageInfo])]
+    :: [(Either SPDX.License Cabal.License, [InstalledPackageInfo])]
     -> IO ()
 printDependencyLicenseList byLicense =
     forM_ byLicense $ \(license, ipis) -> do
-        putStrLn $ "# " ++ Cabal.display license
+        putStrLn $ "# " ++ case license of
+            Left l -> Pretty.prettyShow l
+            Right l -> Cabal.display l
+
         putStrLn ""
 
         let sorted = sortBy (comparing getName) ipis

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
 --------------------------------------------------------------------------------
 module Main
     ( main
@@ -14,6 +15,9 @@ import           Data.Set                           (Set)
 import qualified Data.Set                           as Set
 import qualified Data.Map                           as Map
 import           Distribution.InstalledPackageInfo  (InstalledPackageInfo)
+#if MIN_VERSION_Cabal(2,0,0)
+import qualified Distribution.Utils.ShortText       as ShortText
+#endif
 #if MIN_VERSION_Cabal(2,2,0)
 import qualified Distribution.SPDX.License          as SPDX
 import qualified Distribution.Pretty                as Pretty
@@ -30,6 +34,14 @@ import           System.Exit                        (exitFailure)
 import           System.FilePath                    ((</>), takeDirectory)
 
 import qualified System.FilePath.Find as F
+
+#if MIN_VERSION_Cabal(2,0,0)
+fromShortText :: ShortText.ShortText -> String
+fromShortText = ShortText.fromShortText
+#else
+fromShortText :: String -> String
+fromShortText = id
+#endif
 
 ----------------------------------------------------------------------
 
@@ -151,8 +163,8 @@ printDependencyLicenseList byLicense =
 
         let sorted = sortBy (comparing getName) ipis
         forM_ sorted $ \ipi -> do
-            let synopsis = getSynopsis ipi
-                copyrightStr = InstalledPackageInfo.copyright ipi
+            let synopsis = fromShortText $ getSynopsis ipi
+                copyrightStr = fromShortText $ InstalledPackageInfo.copyright ipi
                 crNotice = case null copyrightStr of
                     True -> ", no copyright notice available"
                     False -> ", Copyright " ++ copyrightStr

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -12,6 +12,7 @@ import           Data.Maybe                         (catMaybes)
 import           Data.Ord                           (comparing)
 import           Data.Set                           (Set)
 import qualified Data.Set                           as Set
+import qualified Data.Map                           as Map
 import           Distribution.InstalledPackageInfo  (InstalledPackageInfo)
 import qualified Distribution.InstalledPackageInfo  as InstalledPackageInfo
 import qualified Distribution.License               as Cabal
@@ -73,7 +74,7 @@ getDependencyInstalledPackageIds lbi =
     findTransitiveDependencies (Cabal.installedPkgs lbi) $
         Set.fromList
             [ installedPackageId
-            | (_, componentLbi, _)    <- Cabal.componentsConfigs lbi
+            | componentLbi    <- concat (Map.elems (Cabal.componentNameMap lbi))
             , (installedPackageId, _) <- Cabal.componentPackageDeps componentLbi
             ]
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -118,7 +118,11 @@ printDependencyLicenseList byLicense =
         let sorted = sortBy (comparing getName) ipis
         forM_ sorted $ \ipi -> do
             let synopsis = getSynopsis ipi
-            putStrLn $ "- " ++ getName ipi ++ " (" ++ synopsis ++ ")"
+                copyrightStr = InstalledPackageInfo.copyright ipi
+                crNotice = case null copyrightStr of
+                    True -> ", no copyright notice available"
+                    False -> ", Copyright " ++ copyrightStr
+            putStrLn $ "- " ++ getName ipi ++ " (" ++ synopsis ++ crNotice ++ ")"
         putStrLn ""
   where
     getName =

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -50,15 +50,15 @@ type PackageIndex a = Cabal.PackageIndex
 
 findTransitiveDependencies
     :: PackageIndex a
-    -> Set Cabal.InstalledPackageId
-    -> Set Cabal.InstalledPackageId
+    -> Set Cabal.UnitId
+    -> Set Cabal.UnitId
 findTransitiveDependencies pkgIdx set0 = go Set.empty (Set.toList set0)
   where
     go set []  = set
     go set (q : queue)
         | q `Set.member` set = go set queue
         | otherwise          =
-            case Cabal.lookupInstalledPackageId pkgIdx q of
+            case Cabal.lookupUnitId pkgIdx q of
                 Nothing  ->
                     -- Not found can mean that the package still needs to be
                     -- installed (e.g. a component of the target cabal package).
@@ -70,14 +70,14 @@ findTransitiveDependencies pkgIdx set0 = go Set.empty (Set.toList set0)
 
 
 --------------------------------------------------------------------------------
-getDependencyInstalledPackageIds
-    :: Cabal.LocalBuildInfo -> Set Cabal.InstalledPackageId
-getDependencyInstalledPackageIds lbi =
+getDependencyUnitIds
+    :: Cabal.LocalBuildInfo -> Set Cabal.UnitId
+getDependencyUnitIds lbi =
     findTransitiveDependencies (Cabal.installedPkgs lbi) $
         Set.fromList
-            [ installedPackageId
+            [ unitId
             | componentLbi    <- concat (Map.elems (Cabal.componentNameMap lbi))
-            , (installedPackageId, _) <- Cabal.componentPackageDeps componentLbi
+            , (unitId, _) <- Cabal.componentPackageDeps componentLbi
             ]
 
 
@@ -85,8 +85,8 @@ getDependencyInstalledPackageIds lbi =
 getDependencyInstalledPackageInfos
     :: Cabal.LocalBuildInfo -> [InstalledPackageInfo]
 getDependencyInstalledPackageInfos lbi = catMaybes $
-    map (Cabal.lookupInstalledPackageId pkgIdx) $
-    Set.toList (getDependencyInstalledPackageIds lbi)
+    map (Cabal.lookupUnitId pkgIdx) $
+    Set.toList (getDependencyUnitIds lbi)
   where
     pkgIdx = Cabal.installedPkgs lbi
 


### PR DESCRIPTION
This change makes it possible to use this tool for binary distributions of Haskell programs where copyright notices of the dependencies need to be collected and included. Since this tool did all the hard work, adding the copyright information was easy.

Thanks!