### PR TITLE
Support new-style builds

### DIFF
--- a/cabal-dependency-licenses.cabal
+++ b/cabal-dependency-licenses.cabal
@@ -24,7 +24,7 @@ Executable cabal-dependency-licenses
   Ghc-options:         -Wall
 
   Build-depends:
-    Cabal      >= 1.18,
+    Cabal      >= 1.18 && < 2.1,
     containers >= 0.5  && < 0.6,
     base       >= 4    && < 5,
     directory  >= 1.2  && < 1.4,

--- a/cabal-dependency-licenses.cabal
+++ b/cabal-dependency-licenses.cabal
@@ -24,7 +24,7 @@ Executable cabal-dependency-licenses
   Ghc-options:         -Wall
 
   Build-depends:
-    Cabal      >= 1.18 && < 2.1,
+    Cabal      >= 2.0  && < 2.1,
     containers >= 0.5  && < 0.6,
     base       >= 4    && < 5,
     directory  >= 1.2  && < 1.4,

--- a/cabal-dependency-licenses.cabal
+++ b/cabal-dependency-licenses.cabal
@@ -24,7 +24,7 @@ Executable cabal-dependency-licenses
   Ghc-options:         -Wall
 
   Build-depends:
-    Cabal      >= 1.18 && < 1.25,
+    Cabal      >= 1.18,
     containers >= 0.5  && < 0.6,
     base       >= 4    && < 5,
     directory  >= 1.2  && < 1.4,

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -7,6 +7,7 @@ module Main
 
 --------------------------------------------------------------------------------
 import           Control.Monad                      (forM_, unless)
+import           Data.Foldable                      (toList)
 import           Data.List                          (foldl', sortBy)
 import           Data.Maybe                         (catMaybes)
 import           Data.Ord                           (comparing)
@@ -79,7 +80,7 @@ getDependencyInstalledPackageIds lbi =
     findTransitiveDependencies (Cabal.installedPkgs lbi) $
         Set.fromList
             [ installedPackageId
-            | (_, componentLbi, _)    <- Cabal.componentsConfigs lbi
+            | (componentLbi)    <- toList (Cabal.componentGraph lbi)
             , (installedPackageId, _) <- Cabal.componentPackageDeps componentLbi
             ]
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -141,8 +141,11 @@ main = do
         putErrLn "No cabal file found in the current directory"
         exitFailure
 
+    -- Check if dist-newstyle should be preferred to dist
+    existsDistNewstyleDir' <- existsDistNewstyleDir
+
     -- Get info and print dependency license list
-    lbi <- Cabal.getPersistBuildConfig "dist"
+    lbi <- Cabal.getPersistBuildConfig (if existsDistNewstyleDir' then "dist-newstyle" else "dist")
     printDependencyLicenseList $
         groupByLicense $
         getDependencyInstalledPackageInfos lbi

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -37,6 +37,11 @@ existsCabalFile = do
     contents <- getDirectoryContents "."
     return $ any ((== ".cabal") . takeExtension) contents
 
+existsCabalProjectFile :: IO Bool
+existsCabalProjectFile = do
+    contents <- getDirectoryContents "."
+    return $ any (== "cabal.project") contents
+
 --------------------------------------------------------------------------------
 #if MIN_VERSION_Cabal(1,24,0)
 type PackageIndex a = Cabal.PackageIndex InstalledPackageInfo.InstalledPackageInfo

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -37,10 +37,10 @@ existsCabalFile = do
     contents <- getDirectoryContents "."
     return $ any ((== ".cabal") . takeExtension) contents
 
-existsCabalProjectFile :: IO Bool
-existsCabalProjectFile = do
+existsDistNewstyleDir :: IO Bool
+existsDistNewstyleDir = do
     contents <- getDirectoryContents "."
-    return $ any (== "cabal.project") contents
+    return $ any (== "dist-newstyle") contents
 
 --------------------------------------------------------------------------------
 #if MIN_VERSION_Cabal(1,24,0)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -48,15 +48,15 @@ type PackageIndex a = Cabal.PackageIndex
 
 findTransitiveDependencies
     :: PackageIndex a
-    -> Set Cabal.InstalledPackageId
-    -> Set Cabal.InstalledPackageId
+    -> Set Cabal.UnitId
+    -> Set Cabal.UnitId
 findTransitiveDependencies pkgIdx set0 = go Set.empty (Set.toList set0)
   where
     go set []  = set
     go set (q : queue)
         | q `Set.member` set = go set queue
         | otherwise          =
-            case Cabal.lookupInstalledPackageId pkgIdx q of
+            case Cabal.lookupUnitId pkgIdx q of
                 Nothing  ->
                     -- Not found can mean that the package still needs to be
                     -- installed (e.g. a component of the target cabal package).
@@ -69,7 +69,7 @@ findTransitiveDependencies pkgIdx set0 = go Set.empty (Set.toList set0)
 
 --------------------------------------------------------------------------------
 getDependencyInstalledPackageIds
-    :: Cabal.LocalBuildInfo -> Set Cabal.InstalledPackageId
+    :: Cabal.LocalBuildInfo -> Set Cabal.UnitId
 getDependencyInstalledPackageIds lbi =
     findTransitiveDependencies (Cabal.installedPkgs lbi) $
         Set.fromList
@@ -83,7 +83,7 @@ getDependencyInstalledPackageIds lbi =
 getDependencyInstalledPackageInfos
     :: Cabal.LocalBuildInfo -> [InstalledPackageInfo]
 getDependencyInstalledPackageInfos lbi = catMaybes $
-    map (Cabal.lookupInstalledPackageId pkgIdx) $
+    map (Cabal.lookupUnitId pkgIdx) $
     Set.toList (getDependencyInstalledPackageIds lbi)
   where
     pkgIdx = Cabal.installedPkgs lbi

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -150,3 +150,8 @@ main = do
     printDependencyLicenseList $
         groupByLicense $
         getDependencyInstalledPackageInfos lbi
+  where
+    usage = do
+      putErrLn "Usage: cabal-dependency-licenses [DIST]"
+      putErrLn "  Print licensing information for the package described in *.cabal & configured in DIST (default: './dist')"
+      exitFailure


### PR DESCRIPTION
This PR:

- Resolves some deprecations arising with Cabal 2.0.
- Adds support for passing the build dir for the component. This supports both projects using old-style builds with build dirs other than `dist`, and new-style builds (with the caveat that you have to pass the full path to the component’s build dir, e.g. `dist-newstyle/build/x86_64-osx/ghc-8.2.1/cabal-dependency-licenses-0.2.0.0/c/cabal-dependency-licenses`).
- Defaults to `dist`, preserving the program’s original behaviour.
- Adds brief usage information to this effect.